### PR TITLE
Force removing gnupg tmp files.

### DIFF
--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -54,7 +54,7 @@ RUN set -x \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && pkill -9 gpg-agent \
     && pkill -9 dirmngr \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu \
     && gosu nobody true \
     && rm -rf /var/lib/apt/lists/*

--- a/9.5/Dockerfile
+++ b/9.5/Dockerfile
@@ -54,7 +54,7 @@ RUN set -x \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && pkill -9 gpg-agent \
     && pkill -9 dirmngr \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu \
     && gosu nobody true \
     && rm -rf /var/lib/apt/lists/*

--- a/9.6/Dockerfile
+++ b/9.6/Dockerfile
@@ -54,7 +54,7 @@ RUN set -x \
     && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
     && pkill -9 gpg-agent \
     && pkill -9 dirmngr \
-    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu \
     && gosu nobody true \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
docker image creation can fail because of not -f.